### PR TITLE
Avoid global variable in header

### DIFF
--- a/tcg/symbolic/symbolic-struct.h
+++ b/tcg/symbolic/symbolic-struct.h
@@ -503,9 +503,9 @@ static inline size_t get_opkind_width(OPKIND opkind)
 }
 
 #define MAX_PRINT_CHECK (1024 * 1024)
-uint8_t            printed[MAX_PRINT_CHECK];
 static inline void print_expr_internal(Expr* expr, uint8_t reset)
 {
+    static uint8_t printed[MAX_PRINT_CHECK];
     if (reset)
         for (size_t i = 0; i < MAX_PRINT_CHECK; i++)
             printed[i] = 0;


### PR DESCRIPTION
Such global would be defined in each compilation unit including the header, preventing them from being linked together, in case of fuzzolic/solver.